### PR TITLE
Fix some issues regarding the substitute command

### DIFF
--- a/command.go
+++ b/command.go
@@ -504,7 +504,7 @@ func (ed *Editor) substitute(re *regexp.Regexp, replace string, nth int, action 
 						return ErrNumberOutOfRange
 					}
 					t.consume()
-					r += submatch[0][n-1]
+					r += submatch[0][n]
 					continue
 				}
 				r += string(t.tok)

--- a/command.go
+++ b/command.go
@@ -503,6 +503,9 @@ func (ed *Editor) substitute(re *regexp.Regexp, replace string, nth int, action 
 					if err != nil {
 						return ErrNumberOutOfRange
 					}
+					if n >= len(submatch[0]) {
+						return ErrNumberOutOfRange
+					}
 					t.consume()
 					r += submatch[0][n]
 					continue

--- a/command.go
+++ b/command.go
@@ -536,7 +536,7 @@ func (ed *Editor) substitute(re *regexp.Regexp, replace string, nth int, action 
 	ed.replacestr = replace
 	if subs == 0 && !ed.g {
 		return ErrNoMatch
-	} else if ed.g && ed.cs&cmdSuffixPrint|cmdSuffixNumber|cmdSuffixList > 0 {
+	} else if ed.g && ed.cs&(cmdSuffixPrint|cmdSuffixNumber|cmdSuffixList) > 0 {
 		return ed.displayLines(ed.dot, ed.dot, ed.cs)
 	}
 	return nil

--- a/command.go
+++ b/command.go
@@ -469,7 +469,7 @@ func (ed *Editor) writeFile(path string, mod rune, start, end int) error {
 
 func (ed *Editor) substitute(re *regexp.Regexp, replace string, nth int, action *[]undoAction) error {
 	var subs int
-	for i := 0; i <= ed.end-ed.start; i++ {
+	for i := ed.start - 1; i < ed.end; i++ {
 		if !re.MatchString(ed.lines[i]) {
 			continue
 		}

--- a/command_test.go
+++ b/command_test.go
@@ -963,6 +963,12 @@ func TestCmdSubstitute(t *testing.T) {
 			err:            []error{nil},
 		},
 		{
+			cmd:            []string{"3,5s/ ./X/\n"},
+			expectedBuffer: []string{"A A A A A", "A A A A A", "BX B B B", "BX B B B", "CX C C C", "C C C C C", "D D D D D", "D D D D D"},
+			expect:         position{start: 3, end: 5, dot: 5, addrc: 2},
+			err:            []error{nil},
+		},
+		{
 			cmd:               []string{",s/A/z/p\n", ",s\n"},
 			expectedBuffer:    []string{"z z A A A", "z z A A A", "B B B B B", "B B B B B", "C C C C C", "C C C C C", "D D D D D", "D D D D D"},
 			expect:            position{start: 1, end: 8, dot: 2, addrc: 2},
@@ -997,9 +1003,9 @@ func TestCmdSubstitute(t *testing.T) {
 		},
 		{
 			cmd:               []string{"s/.*/some/nl\n", ",sp}\n"},
-			expectedBuffer:    append([]string{"some"}, buffer[1:]...),
-			expectedOutput:    "1\tsome$\n",
-			expect:            position{start: 1, end: last, dot: 1, addrc: 2},
+			expectedBuffer:    append(append([]string{}, buffer[:len(buffer)-1]...), "some"),
+			expectedOutput:    "8\tsome$\n",
+			expect:            position{start: 1, end: last, dot: 8, addrc: 2},
 			err:               []error{nil, ErrInvalidCmdSuffix},
 			expectedSubSuffix: subPrint,
 		},

--- a/command_test.go
+++ b/command_test.go
@@ -963,8 +963,8 @@ func TestCmdSubstitute(t *testing.T) {
 			err:            []error{nil},
 		},
 		{
-			cmd:            []string{"3,5s/ ./X/\n"},
-			expectedBuffer: []string{"A A A A A", "A A A A A", "BX B B B", "BX B B B", "CX C C C", "C C C C C", "D D D D D", "D D D D D"},
+			cmd:            []string{`3,5s/ (.)(.)/_\2_\1X\2_/` + "\n"},
+			expectedBuffer: []string{"A A A A A", "A A A A A", "B_ _BX _B B B", "B_ _BX _B B B", "C_ _CX _C C C", "C C C C C", "D D D D D", "D D D D D"},
 			expect:         position{start: 3, end: 5, dot: 5, addrc: 2},
 			err:            []error{nil},
 		},


### PR DESCRIPTION
This pull request addresses issue #1, specifically it

- ensures the _substitute_ command operates on the correct range of lines
- fixes the mapping from replacement expressions like \1 to the 
 corresponding submatch.
- adjusts an if condition so that matched lines are not
 printed unintendedly

Test cases have been adjusted and slightly extended to match the
new behaviour.